### PR TITLE
[COOK-3330] Only adds the helper on windows (fixes crashes on *nix)

### DIFF
--- a/libraries/windows_architecture_helper.rb
+++ b/libraries/windows_architecture_helper.rb
@@ -81,4 +81,6 @@ end
 # Making sure this library is available to Chef::Mixin::PowershellOut
 # Required for clients that don't have Chef::Mixin::WindowsArchitectureHelper in
 # core chef.
-Chef::Mixin::PowershellOut.send(:include, Chef::Mixin::WindowsArchitectureHelper)
+if ::Chef::Platform.windows?
+  Chef::Mixin::PowershellOut.send(:include, Chef::Mixin::WindowsArchitectureHelper)
+end


### PR DESCRIPTION
This fixes a critical bug (anything that includes powershell (even if it's not added as a recipe) won't run at all on *nix, including berkshelf.)

Should fix this ticket: https://tickets.opscode.com/browse/COOK-3330 

Caveats: I don't have a windows system to test on - can't guarantee functionality stays as desired on Win, but it should.
