### PR TITLE
Remove deprecation warning when depend of EOL cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the powershell cookboo
 
 ## Unreleased
 
+Add filter to remove deprecation warning when depends on windows cookbook (EOL cookbook)
+
 Standardise files with files in sous-chefs/repo-management
 
 Standardise files with files in sous-chefs/repo-management

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,5 +10,5 @@ chef_version      '>= 13.0'
 
 supports 'windows'
 
-depends 'windows', '>= 3.0'
+depends 'windows', '>= 3.0' unless Chef::VERSION.to_f >= 14
 depends 'ms_dotnet', '>= 3.2.1'


### PR DESCRIPTION
# Description

Remove deprecation warning when depends of EOL cookbook (windows)

## Issues Resolved

- [Deprecation messsages from windows cookbook](https://github.com/sous-chefs/powershell/issues/149)

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
