### PR TITLE
fix: restore powershell_wmf reboot delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Standardise files with files in sous-chefs/repo-management
 ## Unreleased
 
 * Migrate the cookbook to custom resources and modernize Windows CI/test coverage
+* Reimplement reboot-delay support on the `powershell_wmf` resource
 
 ## [7.0.0](https://github.com/sous-chefs/powershell/compare/v6.4.21...v7.0.0) (2026-04-20)
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Install WMF 5.1 when the target platform needs it:
 powershell_wmf '5.1'
 ```
 
+Request a delayed reboot after installation:
+
+```ruby
+powershell_wmf '4.0' do
+  reboot_mode 'delayed_reboot'
+  reboot_delay_mins 5
+end
+```
+
 Prepare WinRM for DSC with an HTTPS listener:
 
 ```ruby

--- a/documentation/powershell_wmf.md
+++ b/documentation/powershell_wmf.md
@@ -19,6 +19,7 @@ Installs a legacy Windows Management Framework release when the target platform 
 | `timeout` | Integer | computed | Override the installer timeout |
 | `dotnet_version` | String | computed | .NET Framework version requested from `ms_dotnet` |
 | `reboot_mode` | String | `'no_reboot'` | Reboot strategy after installation |
+| `reboot_delay_mins` | Integer | `0` | Delay, in minutes, for `delayed_reboot` requests |
 | `reboot_timeout_seconds` | Integer | `10` | Delay used for delayed reboot requests |
 
 ## Examples
@@ -30,5 +31,6 @@ powershell_wmf '5.1'
 ```ruby
 powershell_wmf '4.0' do
   reboot_mode 'delayed_reboot'
+  reboot_delay_mins 5
 end
 ```

--- a/resources/powershell_wmf.rb
+++ b/resources/powershell_wmf.rb
@@ -10,6 +10,7 @@ property :package, String
 property :timeout, Integer
 property :dotnet_version, String
 property :reboot_mode, String, default: 'no_reboot', equal_to: %w(no_reboot immediate_reboot delayed_reboot)
+property :reboot_delay_mins, Integer, default: 0
 property :reboot_timeout_seconds, Integer, default: 10
 
 default_action :install
@@ -58,7 +59,7 @@ action_class do
 
     reboot 'powershell reboot' do
       reason "PowerShell #{new_resource.version} installation requires a reboot"
-      delay_mins [(new_resource.reboot_timeout_seconds / 60.0).ceil, 1].max
+      delay_mins effective_reboot_delay_mins
       action :nothing
     end
   end
@@ -71,6 +72,13 @@ action_class do
 
   def unsupported_message
     "PowerShell #{new_resource.version} is not supported or already bundled on Windows #{node['platform_version']}"
+  end
+
+  def effective_reboot_delay_mins
+    return new_resource.reboot_delay_mins if new_resource.property_is_set?(:reboot_delay_mins)
+    return 0 if new_resource.reboot_timeout_seconds.to_i <= 0
+
+    [(new_resource.reboot_timeout_seconds / 60.0).ceil, 1].max
   end
 end
 

--- a/spec/unit/resources/powershell_wmf_spec.rb
+++ b/spec/unit/resources/powershell_wmf_spec.rb
@@ -84,6 +84,38 @@ describe 'powershell_wmf' do
     end
   end
 
+  context 'when requesting a delayed reboot with an explicit delay' do
+    platform 'windows', '2012'
+
+    recipe do
+      node.automatic['platform_version'] = '6.1'
+      powershell_wmf '5.1' do
+        reboot_mode 'delayed_reboot'
+        reboot_delay_mins 5
+      end
+    end
+
+    it do
+      expect(chef_run.reboot('powershell reboot').delay_mins).to eq(5)
+    end
+  end
+
+  context 'when using the legacy reboot timeout override' do
+    platform 'windows', '2012'
+
+    recipe do
+      node.automatic['platform_version'] = '6.1'
+      powershell_wmf '5.1' do
+        reboot_mode 'delayed_reboot'
+        reboot_timeout_seconds 120
+      end
+    end
+
+    it do
+      expect(chef_run.reboot('powershell reboot').delay_mins).to eq(2)
+    end
+  end
+
   context 'when PowerShell 5.1 is already bundled with the platform' do
     platform 'windows', '2019'
 


### PR DESCRIPTION
Summary:
- add an explicit reboot_delay_mins property to powershell_wmf for delayed reboot requests
- preserve the legacy reboot_timeout_seconds fallback when no explicit delay is set
- document the new property and cover both paths in ChefSpec

Testing:
- /opt/chef-workstation/embedded/bin/rspec --format documentation
- cookstyle resources/powershell_wmf.rb spec/unit/resources/powershell_wmf_spec.rb